### PR TITLE
fix non-arc, cannot create __weak reference issue

### DIFF
--- a/Source/Networking/GDataProgressMonitorInputStream.h
+++ b/Source/Networking/GDataProgressMonitorInputStream.h
@@ -47,11 +47,11 @@
   unsigned long long dataSize_;     // size of data in the source
   unsigned long long numBytesRead_; // bytes read from the input stream so far
 
-  __weak id monitorDelegate_;
+  id monitorDelegate_;
   SEL monitorSelector_;
   SEL readSelector_;
 
-  __weak id monitorSource_;
+  id monitorSource_;
 }
 
 // length is passed to the progress callback; it may be zero

--- a/Source/Networking/GDataProgressMonitorInputStream.h
+++ b/Source/Networking/GDataProgressMonitorInputStream.h
@@ -47,11 +47,11 @@
   unsigned long long dataSize_;     // size of data in the source
   unsigned long long numBytesRead_; // bytes read from the input stream so far
 
-  id monitorDelegate_;
+  id monitorDelegate_;  //__weak
   SEL monitorSelector_;
   SEL readSelector_;
 
-  id monitorSource_;
+  id monitorSource_; // _weak
 }
 
 // length is passed to the progress callback; it may be zero


### PR DESCRIPTION
for xcode 7, non-arc, cannot create __weak reference
so just remove __weak from GDataProgressMonitorInputStream.h