### PR TITLE
Small cleanups in tests.

### DIFF
--- a/Source/Tests/GDataQueryTest.m
+++ b/Source/Tests/GDataQueryTest.m
@@ -460,7 +460,7 @@
   NSString *fullAsciiParam = @" !\"#$%&'()*+,-./"
     "0123456789:;<=>?@"
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
-    "abcdefghijklmnopqrstuvwxyz{|}~";
+    "abcdefghijklmnopqrstuvwxyz{|}~\x7F";
 
   // full URL encoding leaves +, =, and other URL-legal symbols intact
   NSString *fullEncoded = @"%20!%22%23$%25&'()*+,-./"

--- a/Source/Tests/GDataServiceTest.m
+++ b/Source/Tests/GDataServiceTest.m
@@ -386,7 +386,7 @@ static int gFetchCounter = 0;
                        defaultPropertyValue, @"default property missing");
 
   // no cookies should be sent with our first request
-  NSURLRequest *request = [[ticket_ objectFetcher] mutableRequest];
+  NSURLRequest *request = [[ticket_ objectFetcher] request];
 
   NSString *cookiesSent = [[request allHTTPHeaderFields] objectForKey:@"Cookie"];
   XCTAssertNil(cookiesSent, @"Cookies sent unexpectedly: %@", cookiesSent);
@@ -432,7 +432,7 @@ static int gFetchCounter = 0;
   [self waitForFetch];
 
   // the TestCookie set previously should be sent with this request
-  request = [[ticket_ objectFetcher] mutableRequest];
+  request = [[ticket_ objectFetcher] request];
   cookiesSent = [[request allHTTPHeaderFields] objectForKey:@"Cookie"];
   XCTAssertEqualObjects(cookiesSent, cookieExpected,
                        @"Cookie not sent");


### PR DESCRIPTION
They still don't all pass/build, but a few simple things at the moment.
- Use a hex value in a test string so the source goes back to just being ASC.
- Update a few mutableRequest -> request calls.